### PR TITLE
Integrate badge unlocking

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -91,12 +91,12 @@ export default function RootLayout() {
       <SafeAreaProvider>
         <AuthProvider>
           <ThemeProvider>
-            <UserProvider>
-              <NotificationProvider>
+            <NotificationProvider>
+              <UserProvider>
                 <RootLayoutNav />
                 <StatusBar style="auto" />
-              </NotificationProvider>
-            </UserProvider>
+              </UserProvider>
+            </NotificationProvider>
           </ThemeProvider>
         </AuthProvider>
       </SafeAreaProvider>


### PR DESCRIPTION
## Summary
- evaluate badges whenever XP or user data updates
- show notifications for newly unlocked badges
- move `NotificationProvider` outside of `UserProvider`