### PR TITLE
Add Supabase sync for tasks and quests

### DIFF
--- a/hooks/useTasks.ts
+++ b/hooks/useTasks.ts
@@ -3,6 +3,7 @@ import { Task, NewTaskInput } from '@/types/Task';
 import * as SecureStore from 'expo-secure-store';
 import { Platform } from 'react-native';
 import uuid from 'react-native-uuid';
+import { supabase } from '@/lib/supabase';
 
 // Web localStorage implementation
 const secureStoreWeb = {
@@ -67,21 +68,43 @@ export const useTasks = () => {
   useEffect(() => {
     const loadTasks = async () => {
       try {
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
+
+        if (user) {
+          const { data, error } = await supabase
+            .from('tasks')
+            .select('*')
+            .eq('user_id', user.id);
+
+          if (!error && data) {
+            setTasks(data as Task[]);
+            await secureStore.setItem('dailyxp_tasks', JSON.stringify(data));
+            return;
+          }
+        }
+
         const tasksData = await secureStore.getItem('dailyxp_tasks');
         if (tasksData) {
           setTasks(JSON.parse(tasksData));
         } else {
-          // First time, set sample tasks
           setTasks(sampleTasks);
           await secureStore.setItem('dailyxp_tasks', JSON.stringify(sampleTasks));
         }
       } catch (error) {
         console.error('Failed to load tasks:', error);
+        const tasksData = await secureStore.getItem('dailyxp_tasks');
+        if (tasksData) {
+          setTasks(JSON.parse(tasksData));
+        } else {
+          setTasks(sampleTasks);
+        }
       } finally {
         setLoading(false);
       }
     };
-    
+
     loadTasks();
   }, []);
   
@@ -136,99 +159,206 @@ export const useTasks = () => {
     };
     
     setTasks((prevTasks) => [...prevTasks, newTask]);
+
+    (async () => {
+      try {
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
+        if (user) {
+          await supabase
+            .from('tasks')
+            .insert({ ...newTask, user_id: user.id });
+        }
+      } catch (error) {
+        console.error('Failed to save task to Supabase:', error);
+      }
+    })();
+
     return newTask;
   };
   
   // Update a task
   const updateTask = (taskId: string, updates: Partial<Task>) => {
-    setTasks((prevTasks) => 
-      prevTasks.map((task) => 
-        task.id === taskId ? { ...task, ...updates } : task
-      )
-    );
-  };
-  
-  // Delete a task
-  const deleteTask = (taskId: string) => {
-    setTasks((prevTasks) => prevTasks.filter((task) => task.id !== taskId));
-  };
-  
-  // Mark a task as complete
-  const completeTask = (taskId: string) => {
-    setTasks((prevTasks) => 
+    let updatedTask: Task | null = null;
+    setTasks((prevTasks) =>
       prevTasks.map((task) => {
         if (task.id === taskId) {
-          const updatedTask = { 
-            ...task, 
-            completed: true,
-            completedDate: new Date().toISOString(),
-          };
-          
-          // For habit and daily tasks, increment streak count
-          if (task.type === 'habit' || task.type === 'daily') {
-            updatedTask.streakCount = (task.streakCount || 0) + 1;
-          }
-          
+          updatedTask = { ...task, ...updates };
           return updatedTask;
         }
         return task;
       })
     );
+
+    (async () => {
+      try {
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
+        if (user && updatedTask) {
+          await supabase
+            .from('tasks')
+            .update(updatedTask)
+            .eq('id', taskId)
+            .eq('user_id', user.id);
+        }
+      } catch (error) {
+        console.error('Failed to update task in Supabase:', error);
+      }
+    })();
+  };
+  
+  // Delete a task
+  const deleteTask = (taskId: string) => {
+    setTasks((prevTasks) => prevTasks.filter((task) => task.id !== taskId));
+
+    (async () => {
+      try {
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
+        if (user) {
+          await supabase.from('tasks').delete().eq('id', taskId).eq('user_id', user.id);
+        }
+      } catch (error) {
+        console.error('Failed to delete task from Supabase:', error);
+      }
+    })();
+  };
+  
+  // Mark a task as complete
+  const completeTask = (taskId: string) => {
+    let newTask: Task | null = null;
+    setTasks((prevTasks) =>
+      prevTasks.map((task) => {
+        if (task.id === taskId) {
+          newTask = {
+            ...task,
+            completed: true,
+            completedDate: new Date().toISOString(),
+          };
+
+          if (task.type === 'habit' || task.type === 'daily') {
+            newTask.streakCount = (task.streakCount || 0) + 1;
+          }
+
+          return newTask;
+        }
+        return task;
+      })
+    );
+
+    (async () => {
+      try {
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
+        if (user && newTask) {
+          await supabase
+            .from('tasks')
+            .update(newTask)
+            .eq('id', taskId)
+            .eq('user_id', user.id);
+        }
+      } catch (error) {
+        console.error('Failed to mark task complete in Supabase:', error);
+      }
+    })();
   };
   
   // Reset task completion for daily/habit tasks
   const resetDailyTasks = () => {
     const today = new Date().getDay(); // 0 = Sunday, 1 = Monday, etc.
-    
-    setTasks((prevTasks) => 
+
+    let updated: Task[] = [];
+    setTasks((prevTasks) =>
       prevTasks.map((task) => {
         // Only reset daily tasks
         if (task.type === 'daily') {
           // Check if the task should repeat today
           const shouldRepeatToday = task.repeatDays?.includes(today) ?? true;
-          
+
           if (shouldRepeatToday) {
-            return {
-              ...task,
-              completed: false,
-            };
+            const res = { ...task, completed: false };
+            updated.push(res);
+            return res;
           }
         }
-        
+
         // For habits, always reset
         if (task.type === 'habit') {
-          return {
-            ...task,
-            completed: false,
-          };
+          const res = { ...task, completed: false };
+          updated.push(res);
+          return res;
         }
-        
+
         return task;
       })
     );
+
+    (async () => {
+      try {
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
+        if (user && updated.length) {
+          const updates = updated.map((t) =>
+            supabase
+              .from('tasks')
+              .update({ completed: false })
+              .eq('id', t.id)
+              .eq('user_id', user.id)
+          );
+          await Promise.all(updates);
+        }
+      } catch (error) {
+        console.error('Failed to reset tasks in Supabase:', error);
+      }
+    })();
   };
   
   // Complete a subtask
   const completeSubTask = (taskId: string, subTaskId: string) => {
-    setTasks((prevTasks) => 
+    let updatedTask: Task | null = null;
+    setTasks((prevTasks) =>
       prevTasks.map((task) => {
         if (task.id === taskId && task.subTasks) {
-          const updatedSubTasks = task.subTasks.map((subTask) => 
+          const updatedSubTasks = task.subTasks.map((subTask) =>
             subTask.id === subTaskId ? { ...subTask, completed: true } : subTask
           );
-          
-          // Check if all subtasks are completed
-          const allSubTasksCompleted = updatedSubTasks.every((subTask) => subTask.completed);
-          
-          return {
+
+          const allSubTasksCompleted = updatedSubTasks.every(
+            (subTask) => subTask.completed
+          );
+
+          updatedTask = {
             ...task,
             subTasks: updatedSubTasks,
-            completed: allSubTasksCompleted
+            completed: allSubTasksCompleted,
           };
+          return updatedTask;
         }
         return task;
       })
     );
+
+    (async () => {
+      try {
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
+        if (user && updatedTask) {
+          await supabase
+            .from('tasks')
+            .update({ subTasks: updatedTask.subTasks, completed: updatedTask.completed })
+            .eq('id', taskId)
+            .eq('user_id', user.id);
+        }
+      } catch (error) {
+        console.error('Failed to update subtask in Supabase:', error);
+      }
+    })();
   };
   
   return {

--- a/supabase/migrations/20250608000000_create_tasks_and_quests.sql
+++ b/supabase/migrations/20250608000000_create_tasks_and_quests.sql
@@ -1,0 +1,42 @@
+-- Create tasks table
+create table if not exists tasks (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references auth.users(id) on delete cascade,
+  title text not null,
+  description text,
+  type text not null,
+  category text not null,
+  difficulty text not null,
+  xp_value integer not null,
+  completed boolean default false,
+  due_date date,
+  completed_date timestamptz,
+  streak_count integer default 0,
+  repeat_days jsonb,
+  remind_time text,
+  tags jsonb,
+  sub_tasks jsonb,
+  inserted_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+-- Create quests table
+create table if not exists quests (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references auth.users(id) on delete cascade,
+  title text not null,
+  description text,
+  category text not null,
+  difficulty text not null,
+  status text not null,
+  progress integer not null default 0,
+  xp_reward integer not null,
+  item_reward text,
+  start_date date not null,
+  end_date date,
+  steps jsonb not null,
+  completed boolean default false,
+  inserted_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+


### PR DESCRIPTION
## Summary
- fetch tasks and quests from Supabase when hooks load
- push changes back to Supabase for add/update/delete
- keep SecureStore fallback for offline support
- add migrations creating `tasks` and `quests` tables