### PR TITLE
Fix unused variable in StatsScreen

### DIFF
--- a/app/(tabs)/stats.tsx
+++ b/app/(tabs)/stats.tsx
@@ -60,7 +60,7 @@ const defaultAttributes = {
 };
 
 export default function StatsScreen() {
-  const { theme, isDark } = useTheme();
+  const { isDark } = useTheme();
   const { user } = useUser();
   const { tasks } = useTasks();
   const { quests } = useQuests();


### PR DESCRIPTION
## Summary
- clean up `StatsScreen` by removing the unused `theme` variable