### PR TITLE
Improve stats screen layout

### DIFF
--- a/app/(tabs)/stats.tsx
+++ b/app/(tabs)/stats.tsx
@@ -413,11 +413,12 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   header: {
-    paddingTop: Spacing.md,
+    paddingTop: Spacing.xl,
     paddingBottom: Spacing.xl,
   },
   headerContent: {
     flexDirection: 'column',
+    alignItems: 'center',
     gap: Platform.OS === 'web' ? 16 : 8,
   },
   headerTitle: {
@@ -443,6 +444,7 @@ const styles = StyleSheet.create({
   },
   timeRangeContainer: {
     flexDirection: 'row',
+    marginTop: Spacing.lg,
     marginBottom: Platform.OS === 'web' ? Spacing.lg : Spacing.md,
     gap: Platform.OS === 'web' ? 16 : 8,
   },
@@ -482,8 +484,7 @@ const styles = StyleSheet.create({
   attributeRow: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    justifyContent: 'space-between',
-    alignItems: 'center',
+    justifyContent: 'center',
     gap: Platform.OS === 'web' ? 24 : 12,
   },
   attributeCard: {
@@ -492,7 +493,7 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgba(124, 58, 237, 0.06)',
     borderRadius: BorderRadius.md,
     padding: 12,
-    minWidth: 90,
-    marginBottom: 8,
+    flexBasis: '30%',
+    marginBottom: 12,
   },
 });

--- a/components/stats/StatsCard.tsx
+++ b/components/stats/StatsCard.tsx
@@ -34,11 +34,11 @@ const StatsCard: React.FC<StatsCardProps> = ({
 
 const styles = StyleSheet.create({
   container: {
-    minWidth: 160,
-    padding: Platform.OS === 'web' ? Spacing.lg : Spacing.md,
+    flexBasis: '48%',
+    flexGrow: 1,
+    padding: Spacing.lg,
     borderRadius: BorderRadius.md,
-    marginHorizontal: Platform.OS === 'web' ? 8 : 4,
-    marginBottom: Platform.OS === 'web' ? 0 : Spacing.md,
+    marginBottom: Spacing.md,
   },
   header: {
     flexDirection: 'row',


### PR DESCRIPTION
## Summary
- enlarge Stats cards and arrange them with flexbox
- center header content and increase top padding
- add spacing around time range buttons
- display attributes in a 3-column grid

## Testing
- `npx expo --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68460f694bc88323b6a1a9f9933b1bbf